### PR TITLE
fix: typo causing circular ref

### DIFF
--- a/extract/json_schema/administration.json
+++ b/extract/json_schema/administration.json
@@ -1,4 +1,4 @@
-{ 
+{
   "schema": {
     "type": "object",
     "properties": {
@@ -21,8 +21,8 @@
                   "type": "string",
                   "title": "Facility Type"
               },
-              "facilityDescription": { 
-                "type": "string", 
+              "facilityDescription": {
+                "type": "string",
                 "title": "Facility Description"
               }
           }
@@ -121,7 +121,7 @@
               "title": "Street address"
           }
         }
-      },      
+      },
       "contact":{
         "type": "object",
         "properties": {
@@ -146,7 +146,7 @@
             "title": "Position"
           },
           "address": {
-            "$ref": "#/definitions/contact",
+            "$ref": "#/definitions/address",
             "title": "Address"
           }
         }


### PR DESCRIPTION
The contact definition was referencing itself instead of the address definition (typo). This caused a circular definition reference in the form_json.